### PR TITLE
added support for busy and reset pin as None'able

### DIFF
--- a/adafruit_epd/epd.py
+++ b/adafruit_epd/epd.py
@@ -45,13 +45,15 @@ class Adafruit_EPD:
         self.width = width
         self.height = height
 
-         # Setup reset pin.
+        # Setup reset pin.
         self._rst = rst_pin
-        self._rst.direction = digitalio.Direction.OUTPUT
+        if rst_pin != None:
+            self._rst.direction = digitalio.Direction.OUTPUT
 
-         # Setup busy pin.
+        # Setup busy pin.
         self._busy = busy_pin
-        self._busy.direction = digitalio.Direction.INPUT
+        if busy_pin != None:
+            self._busy.direction = digitalio.Direction.INPUT
 
         # Setup dc pin.
         self._dc = dc_pin
@@ -71,7 +73,7 @@ class Adafruit_EPD:
         self._cs.value = True
         self._dc.value = False
 
-        if reset:
+        if reset and self._rst:            
             self._rst.value = False
             time.sleep(.1)
             self._rst.value = True

--- a/adafruit_epd/epd.py
+++ b/adafruit_epd/epd.py
@@ -73,7 +73,7 @@ class Adafruit_EPD:
         self._cs.value = True
         self._dc.value = False
 
-        if reset and self._rst:            
+        if reset and self._rst:
             self._rst.value = False
             time.sleep(.1)
             self._rst.value = True

--- a/adafruit_epd/il0373.py
+++ b/adafruit_epd/il0373.py
@@ -55,6 +55,7 @@ IL0373_PLL = const(0x30)
 IL0373_CDI = const(0x50)
 IL0373_RESOLUTION = const(0x61)
 IL0373_VCM_DC_SETTING = const(0x82)
+BUSY_WAIT = const(500)
 
 class Adafruit_IL0373(Adafruit_EPD):
     """driver class for Adafruit IL0373 ePaper display breakouts"""
@@ -73,8 +74,11 @@ class Adafruit_IL0373(Adafruit_EPD):
         """Begin communication with the display and set basic settings"""
         super(Adafruit_IL0373, self).begin(reset)
 
-        while self._busy.value is False:
-            pass
+        if self._busy:
+            while self._busy.value is False:
+                pass
+        else:
+            time.sleep(BUSY_WAIT/ 1000)
 
         self.command(IL0373_POWER_SETTING, bytearray([0x03, 0x00, 0x2b, 0x2b, 0x09]))
         self.command(IL0373_BOOSTER_SOFT_START, bytearray([0x17, 0x17, 0x17]))
@@ -83,8 +87,11 @@ class Adafruit_IL0373(Adafruit_EPD):
         """update the display"""
         self.command(IL0373_DISPLAY_REFRESH)
 
-        while self._busy.value is False:
-            pass
+        if self._busy:
+            while self._busy.value is False:
+                pass
+        else:
+            time.sleep(BUSY_WAIT/ 1000)
 
         self.command(IL0373_CDI, bytearray([0x17]))
         self.command(IL0373_VCM_DC_SETTING, bytearray([0x00]))
@@ -95,8 +102,11 @@ class Adafruit_IL0373(Adafruit_EPD):
         """power up the display"""
         self.command(IL0373_POWER_ON)
 
-        while self._busy.value is False:
-            pass
+        if self._busy:
+            while self._busy.value is False:
+                pass
+        else:
+            time.sleep(BUSY_WAIT/ 1000)
 
         time.sleep(.2)
 


### PR DESCRIPTION
Adds support for `rst` and `busy` pin to be `None`.

Tried to mimic the same behavior described in the arduino version ( https://learn.adafruit.com/adafruit-eink-display-breakouts/arduino-code#unnecessary-pins-5-16 )