### PR TITLE
fixed issue #22 and #21

### DIFF
--- a/adafruit_epd/epd.py
+++ b/adafruit_epd/epd.py
@@ -152,6 +152,10 @@ class Adafruit_EPD: # pylint: disable=too-many-instance-attributes, too-many-pub
 
             self._cs.value = True
             self.spi_device.unlock()
+        else:
+            if self.sram:
+                self.sram.cs_pin.value = True
+
         self.update()
 
 


### PR DESCRIPTION
For monochrome Eink display using SRAM, the SRAM SPI CS line now is reset to True state after display is updated. 