### PR TITLE
Reduce the CPU load when waiting for the display

### DIFF
--- a/adafruit_epd/epd.py
+++ b/adafruit_epd/epd.py
@@ -72,7 +72,7 @@ class Adafruit_EPD: # pylint: disable=too-many-instance-attributes, too-many-pub
         # SPI interface (required)
         self.spi_device = spi
         while not self.spi_device.try_lock():
-            pass
+            sleep(0.01)
         self.spi_device.configure(baudrate=1000000) # 1 Mhz
         self.spi_device.unlock()
 
@@ -99,7 +99,7 @@ class Adafruit_EPD: # pylint: disable=too-many-instance-attributes, too-many-pub
 
         if self.sram:
             while not self.spi_device.try_lock():
-                pass
+                sleep(0.01)
             self.sram.cs_pin.value = False
             #send read command
             self._buf[0] = mcp_sram.Adafruit_MCP_SRAM.SRAM_READ
@@ -114,7 +114,7 @@ class Adafruit_EPD: # pylint: disable=too-many-instance-attributes, too-many-pub
         databyte = self.write_ram(0)
 
         while not self.spi_device.try_lock():
-            pass
+            sleep(0.01)
         self._dc.value = True
 
         if self.sram:
@@ -131,7 +131,7 @@ class Adafruit_EPD: # pylint: disable=too-many-instance-attributes, too-many-pub
 
         if self.sram:
             while not self.spi_device.try_lock():
-                pass
+                sleep(0.01)
             self.sram.cs_pin.value = False
             #send read command
             self._buf[0] = mcp_sram.Adafruit_MCP_SRAM.SRAM_READ
@@ -147,7 +147,7 @@ class Adafruit_EPD: # pylint: disable=too-many-instance-attributes, too-many-pub
             databyte = self.write_ram(1)
 
             while not self.spi_device.try_lock():
-                pass
+                sleep(0.01)
             self._dc.value = True
 
             if self.sram:
@@ -182,7 +182,7 @@ class Adafruit_EPD: # pylint: disable=too-many-instance-attributes, too-many-pub
         self._cs.value = False
 
         while not self.spi_device.try_lock():
-            pass
+            sleep(0.01)
         ret = self._spi_transfer(cmd)
 
         if data is not None:

--- a/adafruit_epd/epd.py
+++ b/adafruit_epd/epd.py
@@ -72,7 +72,7 @@ class Adafruit_EPD: # pylint: disable=too-many-instance-attributes, too-many-pub
         # SPI interface (required)
         self.spi_device = spi
         while not self.spi_device.try_lock():
-            sleep(0.01)
+            time.sleep(0.01)
         self.spi_device.configure(baudrate=1000000) # 1 Mhz
         self.spi_device.unlock()
 
@@ -99,7 +99,7 @@ class Adafruit_EPD: # pylint: disable=too-many-instance-attributes, too-many-pub
 
         if self.sram:
             while not self.spi_device.try_lock():
-                sleep(0.01)
+                time.sleep(0.01)
             self.sram.cs_pin.value = False
             #send read command
             self._buf[0] = mcp_sram.Adafruit_MCP_SRAM.SRAM_READ
@@ -114,7 +114,7 @@ class Adafruit_EPD: # pylint: disable=too-many-instance-attributes, too-many-pub
         databyte = self.write_ram(0)
 
         while not self.spi_device.try_lock():
-            sleep(0.01)
+            time.sleep(0.01)
         self._dc.value = True
 
         if self.sram:
@@ -131,7 +131,7 @@ class Adafruit_EPD: # pylint: disable=too-many-instance-attributes, too-many-pub
 
         if self.sram:
             while not self.spi_device.try_lock():
-                sleep(0.01)
+                time.sleep(0.01)
             self.sram.cs_pin.value = False
             #send read command
             self._buf[0] = mcp_sram.Adafruit_MCP_SRAM.SRAM_READ
@@ -147,7 +147,7 @@ class Adafruit_EPD: # pylint: disable=too-many-instance-attributes, too-many-pub
             databyte = self.write_ram(1)
 
             while not self.spi_device.try_lock():
-                sleep(0.01)
+                time.sleep(0.01)
             self._dc.value = True
 
             if self.sram:
@@ -182,7 +182,7 @@ class Adafruit_EPD: # pylint: disable=too-many-instance-attributes, too-many-pub
         self._cs.value = False
 
         while not self.spi_device.try_lock():
-            sleep(0.01)
+            time.sleep(0.01)
         ret = self._spi_transfer(cmd)
 
         if data is not None:

--- a/adafruit_epd/il0373.py
+++ b/adafruit_epd/il0373.py
@@ -96,7 +96,7 @@ class Adafruit_IL0373(Adafruit_EPD):
         busy pin, or pausing"""
         if self._busy:
             while not self._busy.value:
-                pass
+                time.sleep(0.01)
         else:
             time.sleep(0.5)
 

--- a/adafruit_epd/il91874.py
+++ b/adafruit_epd/il91874.py
@@ -105,7 +105,7 @@ class Adafruit_IL91874(Adafruit_EPD):
         busy pin, or pausing"""
         if self._busy:
             while not self._busy.value:
-                pass
+                time.sleep(0.01)
         else:
             time.sleep(0.5)
 


### PR DESCRIPTION
In many places a `pass` instruction is used in loops to wait until we hear back
back from the display. This causes the loop to execute continuously which uses
all of the available CPU, if we instead sleep for 1ms, we don't lose much time
(less than 1ms each wait) and we dramatically reduce the load on the CPU.

Before the change (updating a 3-color 2.13" display):

```
time python3 ./update_display

real    0m19.664s
user    0m17.622s
sys     0m1.046s
```

After the change:

```
time python3 ./update_display

real    0m19.730s
user    0m3.563s
sys     0m0.792s1
```

The total time to run the script is about the same, but the CPU time has reduced dramatically.