### PR TITLE
Split out spi to make guide changes easier

### DIFF
--- a/examples/epd_pillow_demo.py
+++ b/examples/epd_pillow_demo.py
@@ -35,16 +35,16 @@ rst = digitalio.DigitalInOut(board.D27)
 busy = digitalio.DigitalInOut(board.D17)
 
 # give them all to our driver
-# display = Adafruit_SSD1608(200, 200, spi,        # 1.54" HD mono display
-# display = Adafruit_SSD1675(122, 250, spi,        # 2.13" HD mono display
-# display = Adafruit_IL91874(176, 264, spi,        # 2.7" Tri-color display
-# display = Adafruit_IL0373(152, 152, spi,         # 1.54" Tri-color display
-# display = Adafruit_IL0373(128, 296, spi,         # 2.9" Tri-color display
-# display = Adafruit_IL0398(400, 300, spi,         # 4.2" Tri-color display
+# display = Adafruit_SSD1608(200, 200,        # 1.54" HD mono display
+# display = Adafruit_SSD1675(122, 250,        # 2.13" HD mono display
+# display = Adafruit_IL91874(176, 264,        # 2.7" Tri-color display
+# display = Adafruit_IL0373(152, 152,         # 1.54" Tri-color display
+# display = Adafruit_IL0373(128, 296,         # 2.9" Tri-color display
+# display = Adafruit_IL0398(400, 300,         # 4.2" Tri-color display
 display = Adafruit_IL0373(
     104,
-    212,
-    spi,  # 2.13" Tri-color display
+    212,  # 2.13" Tri-color display
+    spi,
     cs_pin=ecs,
     dc_pin=dc,
     sramcs_pin=srcs,

--- a/examples/epd_pillow_image.py
+++ b/examples/epd_pillow_image.py
@@ -26,16 +26,16 @@ rst = digitalio.DigitalInOut(board.D27)
 busy = digitalio.DigitalInOut(board.D17)
 
 # give them all to our driver
-# display = Adafruit_SSD1608(200, 200, spi,        # 1.54" HD mono display
-# display = Adafruit_SSD1675(122, 250, spi,        # 2.13" HD mono display
-# display = Adafruit_IL91874(176, 264, spi,        # 2.7" Tri-color display
-# display = Adafruit_IL0373(152, 152, spi,         # 1.54" Tri-color display
-# display = Adafruit_IL0373(128, 296, spi,         # 2.9" Tri-color display
-# display = Adafruit_IL0398(400, 300, spi,         # 4.2" Tri-color display
+# display = Adafruit_SSD1608(200, 200,        # 1.54" HD mono display
+# display = Adafruit_SSD1675(122, 250,        # 2.13" HD mono display
+# display = Adafruit_IL91874(176, 264,        # 2.7" Tri-color display
+# display = Adafruit_IL0373(152, 152,         # 1.54" Tri-color display
+# display = Adafruit_IL0373(128, 296,         # 2.9" Tri-color display
+# display = Adafruit_IL0398(400, 300,         # 4.2" Tri-color display
 display = Adafruit_IL0373(
     104,
-    212,
-    spi,  # 2.13" Tri-color display
+    212,  # 2.13" Tri-color display
+    spi,
     cs_pin=ecs,
     dc_pin=dc,
     sramcs_pin=srcs,


### PR DESCRIPTION
Since we started using black, it just makes this example terrible for guides. This is my attempt to make it just a little better so people have 1 less line to comment out.