### PR TITLE
Make it easier to run bmp example on Python

### DIFF
--- a/examples/epd_bitmap.py
+++ b/examples/epd_bitmap.py
@@ -49,7 +49,7 @@ display = Adafruit_IL0373(
 
 display.rotation = 0
 
-FILENAME = "blinka154mono.bmp"
+FILENAME = "blinka.bmp"
 
 
 def read_le(s):
@@ -68,7 +68,7 @@ class BMPError(Exception):
 
 def display_bitmap(epd, filename):  # pylint: disable=too-many-locals, too-many-branches
     try:
-        f = open("/" + filename, "rb")
+        f = open(filename, "rb")
     except OSError:
         print("Couldn't open file")
         return

--- a/examples/epd_pillow_image.py
+++ b/examples/epd_pillow_image.py
@@ -71,7 +71,10 @@ image = image.resize((scaled_width, scaled_height), Image.BICUBIC)
 # Crop and center the image
 x = scaled_width // 2 - display.width // 2
 y = scaled_height // 2 - display.height // 2
-image = image.crop((x, y, x + display.width, y + display.height))
+image = image.crop((x, y, x + display.width, y + display.height)).convert("RGB")
+
+# Convert to Monochrome and Add dithering
+# image = image.convert("1").convert("L")
 
 # Display image.
 display.image(image)


### PR DESCRIPTION
Since we're pretty much recommending using displayio for CircuitPython, it doesn't make sense to assume the bitmap is in the root folder. I'll leave the other stuff since we're already telling users to change it in the guides.