### PR TITLE
minor fix to size of demo box; update comments for new mono displays

### DIFF
--- a/examples/epd_pillow_demo.py
+++ b/examples/epd_pillow_demo.py
@@ -41,7 +41,7 @@ busy = digitalio.DigitalInOut(board.D17)
 # give them all to our driver
 # display = Adafruit_SSD1608(200, 200,        # 1.54" HD mono display
 # display = Adafruit_SSD1675(122, 250,        # 2.13" HD mono display
-# display = Adafruit_SSD1680(122, 250,        # 2.13" HD Tri-color display
+# display = Adafruit_SSD1680(122, 250,        # 2.13" HD Tri-color or mono display
 # display = Adafruit_SSD1681(200, 200,        # 1.54" HD Tri-color display
 # display = Adafruit_IL91874(176, 264,        # 2.7" Tri-color display
 # display = Adafruit_IL0373(152, 152,         # 1.54" Tri-color display
@@ -70,7 +70,7 @@ image = Image.new("RGB", (display.width, display.height))
 draw = ImageDraw.Draw(image)
 
 # Draw a filled box as the background
-draw.rectangle((0, 0, display.width, display.height), fill=BACKGROUND_COLOR)
+draw.rectangle((0, 0, display.width - 1, display.height - 1), fill=BACKGROUND_COLOR)
 
 # Draw a smaller inner foreground rectangle
 draw.rectangle(

--- a/examples/epd_pillow_image.py
+++ b/examples/epd_pillow_image.py
@@ -32,7 +32,7 @@ busy = digitalio.DigitalInOut(board.D17)
 # give them all to our driver
 # display = Adafruit_SSD1608(200, 200,        # 1.54" HD mono display
 # display = Adafruit_SSD1675(122, 250,        # 2.13" HD mono display
-# display = Adafruit_SSD1680(122, 250,        # 2.13" HD Tri-color display
+# display = Adafruit_SSD1680(122, 250,        # 2.13" HD Tri-color or mono display
 # display = Adafruit_SSD1681(200, 200,        # 1.54" HD Tri-color display
 # display = Adafruit_IL91874(176, 264,        # 2.7" Tri-color display
 # display = Adafruit_IL0373(152, 152,         # 1.54" Tri-color display


### PR DESCRIPTION
Hi, this is my first time opening a pull request on a project, but I was going through the great tutorial+demo code for the 2.13" mono E Ink display (thanks!) and noticed one place a comment could be updated (SSD1680 chipset is used by both tricolor and this mono display), and one off-by-one drawn rectangle size in the demo (no actually visible effect as it just draws the rectangle one pixel wider than necessary).

So I updated them locally for my own use and thought I'd try contributing back.

But if these changes are too minor and no-impact to be worth reviewing / merging, no problem. :)