### PR TITLE
Fix #52 Distinguish stride from width for SSD1680

### DIFF
--- a/adafruit_epd/ssd1680.py
+++ b/adafruit_epd/ssd1680.py
@@ -78,10 +78,11 @@ class Adafruit_SSD1680(Adafruit_EPD):
             width, height, spi, cs_pin, dc_pin, sramcs_pin, rst_pin, busy_pin
         )
 
-        if width % 8 != 0:
-            width += 8 - width % 8
+        stride = width
+        if stride % 8 != 0:
+            stride += 8 - stride % 8
 
-        self._buffer1_size = int(width * height / 8)
+        self._buffer1_size = int(stride * height / 8)
         self._buffer2_size = self._buffer1_size
 
         if sramcs_pin:
@@ -92,10 +93,18 @@ class Adafruit_SSD1680(Adafruit_EPD):
             self._buffer2 = bytearray(self._buffer2_size)
 
         self._framebuf1 = adafruit_framebuf.FrameBuffer(
-            self._buffer1, width, height, buf_format=adafruit_framebuf.MHMSB
+            self._buffer1,
+            width,
+            height,
+            stride=stride,
+            buf_format=adafruit_framebuf.MHMSB,
         )
         self._framebuf2 = adafruit_framebuf.FrameBuffer(
-            self._buffer2, width, height, buf_format=adafruit_framebuf.MHMSB
+            self._buffer2,
+            width,
+            height,
+            stride=stride,
+            buf_format=adafruit_framebuf.MHMSB,
         )
         self.set_black_buffer(0, True)
         self.set_color_buffer(1, False)


### PR DESCRIPTION
Apply fix from 8022b34 to Adafruit_SSD1680, allowing rotations of 1 and
2 to be used even when width is not a multiple of 8.