### PR TITLE
Acep 7color

### DIFF
--- a/adafruit_epd/acep_7color.py
+++ b/adafruit_epd/acep_7color.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: 2023 Liz Clark for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_epd.ACEP` - Adafruit ACEP - ePaper display driver
+====================================================================================
+CircuitPython driver for Adafruit ACEP display breakouts
+* Author(s): Dean Miller
+"""
+
+import time
+import PIL
+from PIL import Image
+from micropython import const
+import adafruit_framebuf
+from adafruit_epd.epd import Adafruit_EPD
+
+__version__ = "0.0.0+auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_EPD.git"
+
+_ACEP_PANEL_SETTING = const(0x00)
+_ACEP_POWER_SETTING = const(0x01)
+_ACEP_POWER_OFF = const(0x02)
+_ACEP_POWER_OFF_SEQUENCE = const(0x03)
+_ACEP_POWER_ON = const(0x04)
+_ACEP_BOOSTER_SOFT_START = const(0x06)
+_ACEP_DEEP_SLEEP = const(0x07)
+_ACEP_DTM = const(0x10)
+_ACEP_DISPLAY_REFRESH = const(0x12)
+_ACEP_PLL = const(0x30)
+_ACEP_TSE = const(0x40)
+_ACEP_CDI = const(0x50)
+_ACEP_TCON = const(0X60)
+_ACEP_RESOLUTION = const(0x61)
+_ACEP_PWS = const(0xE3)
+
+class Adafruit_ACEP(Adafruit_EPD):
+    """driver class for Adafruit ACEP ePaper display breakouts"""
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self, width, height, spi, *, cs_pin, dc_pin, sramcs_pin, rst_pin, busy_pin
+    ):
+        super().__init__(
+            width, height, spi, cs_pin, dc_pin, sramcs_pin, rst_pin, busy_pin
+        )
+        
+        if ((height % 8) != 0):
+            height += 8 - (height % 8)
+        
+        self._buffer1_size = int(width * height / 2)
+        self._buffer2_size = 0
+
+        if sramcs_pin:
+            self._buffer1 = 0
+            self._buffer2 = 0
+        else:
+            self._buffer1 = bytearray(self._buffer1_size)
+            self._buffer2 = self._buffer1
+
+        self._framebuf1 = adafruit_framebuf.FrameBuffer(
+            self._buffer1, width, height, buf_format=adafruit_framebuf.MHMSB
+        )
+
+        self.set_black_buffer(0, True)
+        self.set_color_buffer(0, True)
+        # pylint: enable=too-many-arguments
+
+    def begin(self, reset=True):
+        """Begin communication with the display and set basic settings"""
+        if reset:
+            self.hardware_reset()
+        self.power_down()
+
+    def busy_wait(self):
+        """Wait for display to be done with current task, either by polling the
+        busy pin, or pausing"""
+        if self._busy:
+            while not self._busy.value:
+                time.sleep(0.1)
+        else:
+            time.sleep(0.5)
+
+    def power_up(self):
+        """Power up the display in preparation for writing RAM and updating"""
+        self.hardware_reset()
+        time.sleep(0.2)
+        self.busy_wait()
+
+        time.sleep(0.1)
+        self.command(_ACEP_PANEL_SETTING, bytearray([0xEF, 0x08]))
+        self.command(_ACEP_POWER_SETTING, bytearray([0x37, 0x00, 0x23, 0x23]))
+        self.command(_ACEP_POWER_OFF_SEQUENCE, bytearray([0x00]))
+        self.command(_ACEP_BOOSTER_SOFT_START, bytearray([0xC7, 0xC7, 0x1D]))
+        self.command(_ACEP_PLL, bytearray([0x3C]))
+        self.command(_ACEP_TSE, bytearray([0x00]))
+        self.command(_ACEP_CDI, bytearray([0x37]))
+        self.command(_ACEP_TCON, bytearray([0x22]))
+        self.command(_ACEP_RESOLUTION, bytearray([0x02, 0x58, 0x01, 0xC0]))
+        self.command(_ACEP_PWS, bytearray([0xAA]))
+        time.sleep(0.1)
+        self.command(_ACEP_CDI, bytearray([0x37]))
+        
+        self.command(_ACEP_RESOLUTION, bytearray([0x02, 0x58, 0x01, 0xC0]))
+        time.sleep(0.1)
+
+    def power_down(self):
+        """Power down the display - required when not actively displaying!"""
+        time.sleep(1)
+
+        self.command(_ACEP_DEEP_SLEEP, bytearray([0xA5]))
+        
+        time.sleep(0.1)
+
+    def update(self):
+        """Update the display from internal memory"""
+        self.command(_ACEP_POWER_ON)
+        self.busy_wait()
+        self.command(_ACEP_DISPLAY_REFRESH, bytearray([0x01, 0x00]))
+        self.busy_wait()
+        self.command(_ACEP_POWER_OFF)
+        if not self._busy:
+            time.sleep(15)  # wait 15 seconds
+        else:
+            self.busy_wait()
+
+    def write_ram(self, index):
+        """Send the one byte command for starting the RAM write process. Returns
+        the byte read at the same time over SPI. index is the RAM buffer, can be
+        0 or 1 for tri-color displays."""
+        #self.command(_ACEP_DTM, end=False)
+        if index == 0:
+            return self.command(_ACEP_DTM, end=False)
+        if index == 1:
+            return self.command(_ACEP_DTM, end=False)
+        raise RuntimeError("RAM index must be 0 or 1")
+
+    def set_ram_address(self, x, y):  # pylint: disable=unused-argument, no-self-use
+        """Set the RAM address location, not used on this chipset but required by
+        the superclass"""
+        return  # on this chip it does nothing

--- a/adafruit_epd/acep_7color.py
+++ b/adafruit_epd/acep_7color.py
@@ -10,8 +10,6 @@ CircuitPython driver for Adafruit ACEP display breakouts
 """
 
 import time
-import PIL
-from PIL import Image
 from micropython import const
 import adafruit_framebuf
 from adafruit_epd.epd import Adafruit_EPD
@@ -31,9 +29,10 @@ _ACEP_DISPLAY_REFRESH = const(0x12)
 _ACEP_PLL = const(0x30)
 _ACEP_TSE = const(0x40)
 _ACEP_CDI = const(0x50)
-_ACEP_TCON = const(0X60)
+_ACEP_TCON = const(0x60)
 _ACEP_RESOLUTION = const(0x61)
 _ACEP_PWS = const(0xE3)
+
 
 class Adafruit_ACEP(Adafruit_EPD):
     """driver class for Adafruit ACEP ePaper display breakouts"""
@@ -45,10 +44,10 @@ class Adafruit_ACEP(Adafruit_EPD):
         super().__init__(
             width, height, spi, cs_pin, dc_pin, sramcs_pin, rst_pin, busy_pin
         )
-        
-        if ((height % 8) != 0):
+
+        if (height % 8) != 0:
             height += 8 - (height % 8)
-        
+
         self._buffer1_size = int(width * height / 2)
         self._buffer2_size = 0
 
@@ -101,7 +100,7 @@ class Adafruit_ACEP(Adafruit_EPD):
         self.command(_ACEP_PWS, bytearray([0xAA]))
         time.sleep(0.1)
         self.command(_ACEP_CDI, bytearray([0x37]))
-        
+
         self.command(_ACEP_RESOLUTION, bytearray([0x02, 0x58, 0x01, 0xC0]))
         time.sleep(0.1)
 
@@ -110,7 +109,7 @@ class Adafruit_ACEP(Adafruit_EPD):
         time.sleep(1)
 
         self.command(_ACEP_DEEP_SLEEP, bytearray([0xA5]))
-        
+
         time.sleep(0.1)
 
     def update(self):
@@ -129,7 +128,7 @@ class Adafruit_ACEP(Adafruit_EPD):
         """Send the one byte command for starting the RAM write process. Returns
         the byte read at the same time over SPI. index is the RAM buffer, can be
         0 or 1 for tri-color displays."""
-        #self.command(_ACEP_DTM, end=False)
+        # self.command(_ACEP_DTM, end=False)
         if index == 0:
             return self.command(_ACEP_DTM, end=False)
         if index == 1:

--- a/adafruit_epd/epd.py
+++ b/adafruit_epd/epd.py
@@ -27,6 +27,12 @@ class Adafruit_EPD:  # pylint: disable=too-many-instance-attributes, too-many-pu
     RED = const(3)
     DARK = const(4)
     LIGHT = const(5)
+    
+    acep_GREEN  = const(2)
+    acep_BLUE   = const(3)
+    acep_RED    = const(4)
+    acep_YELLOW = const(5)
+    acep_ORANGE = const(6)
 
     def __init__(
         self, width, height, spi, cs_pin, dc_pin, sramcs_pin, rst_pin, busy_pin
@@ -248,28 +254,47 @@ class Adafruit_EPD:  # pylint: disable=too-many-instance-attributes, too-many-pu
 
     def _color_dup(self, func, args, color):
         black = getattr(self._blackframebuf, func)
+        green = getattr(self._colorframebuf, func)
+        blue = getattr(self._colorframebuf, func)
         red = getattr(self._colorframebuf, func)
-        if self._blackframebuf is self._colorframebuf:  # monochrome
+        yellow = getattr(self._colorframebuf, func)
+        orange = getattr(self._colorframebuf, func)
+        '''if self._blackframebuf is self._colorframebuf:  # monochrome
             black(*args, color=(color != Adafruit_EPD.WHITE) != self._black_inverted)
-        else:
-            black(*args, color=(color == Adafruit_EPD.BLACK) != self._black_inverted)
-            red(*args, color=(color == Adafruit_EPD.RED) != self._color_inverted)
+        else:'''
+        black(*args, color=(color == Adafruit_EPD.BLACK) != self._black_inverted)
+        red(*args, color=(color == Adafruit_EPD.acep_RED or color == Adafruit_EPD.RED) != self._color_inverted)
+        blue(*args, color=(color == Adafruit_EPD.acep_BLUE) != self._color_inverted)
+        green(*args, color=(color == Adafruit_EPD.acep_GREEN) != self._color_inverted)
+        yellow(*args, color=(color == Adafruit_EPD.acep_YELLOW) != self._color_inverted)
+        orange(*args, color=(color == Adafruit_EPD.acep_ORANGE) != self._color_inverted)
 
     def pixel(self, x, y, color):
         """draw a single pixel in the display buffer"""
         self._color_dup("pixel", (x, y), color)
-
+    
     def fill(self, color):
         """fill the screen with the passed color"""
-        red_fill = ((color == Adafruit_EPD.RED) != self._color_inverted) * 0xFF
         black_fill = ((color == Adafruit_EPD.BLACK) != self._black_inverted) * 0xFF
-
+        green_fill = ((color == Adafruit_EPD.acep_GREEN) != self._color_inverted) * 0xFF
+        blue_fill = ((color == Adafruit_EPD.acep_BLUE) != self._color_inverted) * 0xFF
+        red_fill = ((color == Adafruit_EPD.acep_RED or color == Adafruit_EPD.RED) != self._color_inverted) * 0xFF
+        yellow_fill = ((color == Adafruit_EPD.acep_YELLOW) != self._color_inverted) * 0xFF
+        orange_fill = ((color == Adafruit_EPD.acep_ORANGE) != self._color_inverted) * 0xFF
         if self.sram:
             self.sram.erase(0x00, self._buffer1_size, black_fill)
+            self.sram.erase(self._buffer1_size, self._buffer2_size, green_fill)
+            self.sram.erase(self._buffer1_size, self._buffer2_size, blue_fill)
             self.sram.erase(self._buffer1_size, self._buffer2_size, red_fill)
+            self.sram.erase(self._buffer1_size, self._buffer2_size, yellow_fill)
+            self.sram.erase(self._buffer1_size, self._buffer2_size, orange_fill)
         else:
             self._blackframebuf.fill(black_fill)
+            self._colorframebuf.fill(green_fill)
+            self._colorframebuf.fill(blue_fill)
             self._colorframebuf.fill(red_fill)
+            self._colorframebuf.fill(yellow_fill)
+            self._colorframebuf.fill(orange_fill)
 
     def rect(self, x, y, width, height, color):  # pylint: disable=too-many-arguments
         """draw a rectangle"""

--- a/adafruit_epd/epd.py
+++ b/adafruit_epd/epd.py
@@ -27,10 +27,10 @@ class Adafruit_EPD:  # pylint: disable=too-many-instance-attributes, too-many-pu
     RED = const(3)
     DARK = const(4)
     LIGHT = const(5)
-    
-    acep_GREEN  = const(2)
-    acep_BLUE   = const(3)
-    acep_RED    = const(4)
+
+    acep_GREEN = const(2)
+    acep_BLUE = const(3)
+    acep_RED = const(4)
     acep_YELLOW = const(5)
     acep_ORANGE = const(6)
 
@@ -259,11 +259,16 @@ class Adafruit_EPD:  # pylint: disable=too-many-instance-attributes, too-many-pu
         red = getattr(self._colorframebuf, func)
         yellow = getattr(self._colorframebuf, func)
         orange = getattr(self._colorframebuf, func)
-        '''if self._blackframebuf is self._colorframebuf:  # monochrome
+        # pylint: disable=pointless-string-statement
+        """if self._blackframebuf is self._colorframebuf:  # monochrome
             black(*args, color=(color != Adafruit_EPD.WHITE) != self._black_inverted)
-        else:'''
+        else:"""
         black(*args, color=(color == Adafruit_EPD.BLACK) != self._black_inverted)
-        red(*args, color=(color == Adafruit_EPD.acep_RED or color == Adafruit_EPD.RED) != self._color_inverted)
+        red(
+            *args,
+            color=(color in Adafruit_EPD.acep_RED, Adafruit_EPD.RED)
+            != self._color_inverted
+        )
         blue(*args, color=(color == Adafruit_EPD.acep_BLUE) != self._color_inverted)
         green(*args, color=(color == Adafruit_EPD.acep_GREEN) != self._color_inverted)
         yellow(*args, color=(color == Adafruit_EPD.acep_YELLOW) != self._color_inverted)
@@ -272,15 +277,21 @@ class Adafruit_EPD:  # pylint: disable=too-many-instance-attributes, too-many-pu
     def pixel(self, x, y, color):
         """draw a single pixel in the display buffer"""
         self._color_dup("pixel", (x, y), color)
-    
+
     def fill(self, color):
         """fill the screen with the passed color"""
         black_fill = ((color == Adafruit_EPD.BLACK) != self._black_inverted) * 0xFF
         green_fill = ((color == Adafruit_EPD.acep_GREEN) != self._color_inverted) * 0xFF
         blue_fill = ((color == Adafruit_EPD.acep_BLUE) != self._color_inverted) * 0xFF
-        red_fill = ((color == Adafruit_EPD.acep_RED or color == Adafruit_EPD.RED) != self._color_inverted) * 0xFF
-        yellow_fill = ((color == Adafruit_EPD.acep_YELLOW) != self._color_inverted) * 0xFF
-        orange_fill = ((color == Adafruit_EPD.acep_ORANGE) != self._color_inverted) * 0xFF
+        red_fill = (
+            (color in Adafruit_EPD.acep_RED, Adafruit_EPD.RED) != self._color_inverted
+        ) * 0xFF
+        yellow_fill = (
+            (color == Adafruit_EPD.acep_YELLOW) != self._color_inverted
+        ) * 0xFF
+        orange_fill = (
+            (color == Adafruit_EPD.acep_ORANGE) != self._color_inverted
+        ) * 0xFF
         if self.sram:
             self.sram.erase(0x00, self._buffer1_size, black_fill)
             self.sram.erase(self._buffer1_size, self._buffer2_size, green_fill)

--- a/examples/acep_colorsquares_test.py
+++ b/examples/acep_colorsquares_test.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+import time
+import digitalio
+import busio
+import board
+import PIL
+from PIL import Image
+from adafruit_epd.epd import Adafruit_EPD
+from adafruit_epd.acep_7color import Adafruit_ACEP
+
+#print(dir(board))
+# create the spi device and pins we will need
+spi = busio.SPI(board.EPD_SCK, MOSI=board.EPD_MOSI, MISO=None)
+epd_cs = digitalio.DigitalInOut(board.EPD_CS)
+epd_dc = digitalio.DigitalInOut(board.EPD_DC)
+epd_reset = digitalio.DigitalInOut(board.EPD_RESET)
+epd_busy =  digitalio.DigitalInOut(board.EPD_BUSY)
+srcs = None
+
+display = Adafruit_ACEP(600, 448, spi, cs_pin=epd_cs, dc_pin=epd_dc, sramcs_pin=srcs, rst_pin=epd_reset, busy_pin=epd_busy)
+
+display.fill(Adafruit_EPD.WHITE)
+
+display.fill_rect(30, 20, 20, 20, Adafruit_EPD.BLACK)
+display.fill_rect(70, 10, 20, 20, Adafruit_EPD.acep_BLUE)
+display.fill_rect(110, 10, 20, 20, Adafruit_EPD.acep_RED)
+display.fill_rect(150, 10, 20, 20, Adafruit_EPD.acep_GREEN)
+display.fill_rect(190, 10, 20, 20, Adafruit_EPD.acep_YELLOW)
+display.fill_rect(230, 10, 20, 20, Adafruit_EPD.acep_ORANGE)
+
+display.display()

--- a/examples/acep_colorsquares_test.py
+++ b/examples/acep_colorsquares_test.py
@@ -1,25 +1,30 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
-import time
 import digitalio
 import busio
 import board
-import PIL
-from PIL import Image
 from adafruit_epd.epd import Adafruit_EPD
 from adafruit_epd.acep_7color import Adafruit_ACEP
 
-#print(dir(board))
 # create the spi device and pins we will need
 spi = busio.SPI(board.EPD_SCK, MOSI=board.EPD_MOSI, MISO=None)
 epd_cs = digitalio.DigitalInOut(board.EPD_CS)
 epd_dc = digitalio.DigitalInOut(board.EPD_DC)
 epd_reset = digitalio.DigitalInOut(board.EPD_RESET)
-epd_busy =  digitalio.DigitalInOut(board.EPD_BUSY)
+epd_busy = digitalio.DigitalInOut(board.EPD_BUSY)
 srcs = None
 
-display = Adafruit_ACEP(600, 448, spi, cs_pin=epd_cs, dc_pin=epd_dc, sramcs_pin=srcs, rst_pin=epd_reset, busy_pin=epd_busy)
+display = Adafruit_ACEP(
+    600,
+    448,
+    spi,
+    cs_pin=epd_cs,
+    dc_pin=epd_dc,
+    sramcs_pin=srcs,
+    rst_pin=epd_reset,
+    busy_pin=epd_busy,
+)
 
 display.fill(Adafruit_EPD.WHITE)
 


### PR DESCRIPTION
hihi @tannewt & @ladyada - here is the work i've tried so far on the ACeP support. still only getting black and white. i was trying to have it work with how the tricolor displays are written to but the issue with that, if i'm understanding everything correctly, is that the library expects two framebuffers for color displays and the acep only has one ([i was referencing the arduino driver](https://github.com/adafruit/Adafruit_EPD/blob/master/src/drivers/Adafruit_ACeP.cpp)).

there's an if/else in _color_dup that checks if the black frame buffer and the color frame buffer are the same and if they are it recognizes it as a monochrome display. i have that commented out here for testing. i noticed in the circuitpython displayio version that there is a parameter that checks if it is an adv color display so maybe i should be adding something like that?