### PR TITLE
Fix Unions to Literals

### DIFF
--- a/adafruit_epd/epd.py
+++ b/adafruit_epd/epd.py
@@ -18,6 +18,7 @@ from adafruit_epd import mcp_sram
 try:
     """Needed for type annotations"""
     from typing import Any, Union, Callable, Optional
+    from typing_extensions import Literal
     from busio import SPI
     from digitalio import DigitalInOut
     from circuitpython_typing.pil import Image
@@ -247,7 +248,7 @@ class Adafruit_EPD:  # pylint: disable=too-many-instance-attributes, too-many-pu
         """Set the RAM address location, must be implemented in subclass"""
         raise NotImplementedError()
 
-    def set_black_buffer(self, index: Union[0, 1], inverted: bool) -> None:
+    def set_black_buffer(self, index: Literal[0, 1], inverted: bool) -> None:
         """Set the index for the black buffer data (0 or 1) and whether its inverted"""
         if index == 0:
             self._blackframebuf = self._framebuf1
@@ -257,7 +258,7 @@ class Adafruit_EPD:  # pylint: disable=too-many-instance-attributes, too-many-pu
             raise RuntimeError("Buffer index must be 0 or 1")
         self._black_inverted = inverted
 
-    def set_color_buffer(self, index: Union[0, 1], inverted: bool) -> None:
+    def set_color_buffer(self, index: Literal[0, 1], inverted: bool) -> None:
         """Set the index for the color buffer data (0 or 1) and whether its inverted"""
         if index == 0:
             self._colorframebuf = self._framebuf1
@@ -271,7 +272,7 @@ class Adafruit_EPD:  # pylint: disable=too-many-instance-attributes, too-many-pu
         self,
         func: Callable,
         args: Any,
-        color: Union[0, 1, 2, 3, 4, 5],
+        color: Literal[0, 1, 2, 3, 4, 5],
     ) -> None:
         black = getattr(self._blackframebuf, func)
         red = getattr(self._colorframebuf, func)
@@ -368,7 +369,7 @@ class Adafruit_EPD:  # pylint: disable=too-many-instance-attributes, too-many-pu
         return self._width
 
     @property
-    def rotation(self) -> Union[0, 1, 2, 3]:
+    def rotation(self) -> Literal[0, 1, 2, 3]:
         """The rotation of the display, can be one of (0, 1, 2, 3)"""
         return self._framebuf1.rotation
 

--- a/adafruit_epd/il0373.py
+++ b/adafruit_epd/il0373.py
@@ -16,7 +16,8 @@ from adafruit_epd.epd import Adafruit_EPD
 
 try:
     """Needed for type annotations"""
-    from typing import Union
+    import typing  # pylint: disable=unused-import
+    from typing_extensions import Literal
     from busio import SPI
     from digitalio import DigitalInOut
 
@@ -144,7 +145,7 @@ class Adafruit_IL0373(Adafruit_EPD):
         if not self._busy:
             time.sleep(15)  # wait 15 seconds
 
-    def write_ram(self, index: Union[0, 1]) -> int:
+    def write_ram(self, index: Literal[0, 1]) -> int:
         """Send the one byte command for starting the RAM write process. Returns
         the byte read at the same time over SPI. index is the RAM buffer, can be
         0 or 1 for tri-color displays."""

--- a/adafruit_epd/il0398.py
+++ b/adafruit_epd/il0398.py
@@ -16,7 +16,8 @@ from adafruit_epd.epd import Adafruit_EPD
 
 try:
     """Needed for type annotations"""
-    from typing import Union
+    import typing  # pylint: disable=unused-import
+    from typing_extensions import Literal
     from busio import SPI
     from digitalio import DigitalInOut
 
@@ -144,7 +145,7 @@ class Adafruit_IL0398(Adafruit_EPD):
         if not self._busy:
             time.sleep(15)  # wait 15 seconds
 
-    def write_ram(self, index: Union[0, 1]) -> int:
+    def write_ram(self, index: Literal[0, 1]) -> int:
         """Send the one byte command for starting the RAM write process. Returns
         the byte read at the same time over SPI. index is the RAM buffer, can be
         0 or 1 for tri-color displays."""

--- a/adafruit_epd/il91874.py
+++ b/adafruit_epd/il91874.py
@@ -16,7 +16,8 @@ from adafruit_epd.epd import Adafruit_EPD
 
 try:
     "Needed for type annotations"
-    from typing import Union
+    import typing  # pylint: disable=unused-import
+    from typing_extensions import Literal
     from busio import SPI
     from digitalio import DigitalInOut
 
@@ -167,7 +168,7 @@ class Adafruit_IL91874(Adafruit_EPD):
         if not self._busy:
             time.sleep(16)  # wait 16 seconds
 
-    def write_ram(self, index: Union[0, 1]) -> int:
+    def write_ram(self, index: Literal[0, 1]) -> int:
         """Send the one byte command for starting the RAM write process. Returns
         the byte read at the same time over SPI. index is the RAM buffer, can be
         0 or 1 for tri-color displays."""

--- a/adafruit_epd/ssd1608.py
+++ b/adafruit_epd/ssd1608.py
@@ -16,7 +16,8 @@ from adafruit_epd.epd import Adafruit_EPD
 
 try:
     """Needed for type annotations"""
-    from typing import Union
+    import typing  # pylint: disable=unused-import
+    from typing_extensions import Literal
     from busio import SPI
     from digitalio import DigitalInOut
 
@@ -156,7 +157,7 @@ class Adafruit_SSD1608(Adafruit_EPD):
         if not self._busy:
             time.sleep(3)  # wait 3 seconds
 
-    def write_ram(self, index: Union[0]) -> int:
+    def write_ram(self, index: Literal[0]) -> int:
         """Send the one byte command for starting the RAM write process. Returns
         the byte read at the same time over SPI. index is the RAM buffer, can be
         0 or 1 for tri-color displays."""

--- a/adafruit_epd/ssd1675.py
+++ b/adafruit_epd/ssd1675.py
@@ -16,7 +16,8 @@ from adafruit_epd.epd import Adafruit_EPD
 
 try:
     """Needed for type annotations"""
-    from typing import Union
+    import typing  # pylint: disable=unused-import
+    from typing_extensions import Literal
     from busio import SPI
     from digitalio import DigitalInOut
 
@@ -178,7 +179,7 @@ class Adafruit_SSD1675(Adafruit_EPD):
         if not self._busy:
             time.sleep(3)  # wait 3 seconds
 
-    def write_ram(self, index: Union[0, 1]) -> int:
+    def write_ram(self, index: Literal[0, 1]) -> int:
         """Send the one byte command for starting the RAM write process. Returns
         the byte read at the same time over SPI. index is the RAM buffer, can be
         0 or 1 for tri-color displays."""

--- a/adafruit_epd/ssd1675b.py
+++ b/adafruit_epd/ssd1675b.py
@@ -16,7 +16,8 @@ from adafruit_epd.epd import Adafruit_EPD
 
 try:
     """Needed for type annotations"""
-    from typing import Union
+    import typing  # pylint: disable=unused-import
+    from typing_extensions import Literal
     from busio import SPI
     from digitalio import DigitalInOut
 
@@ -220,7 +221,7 @@ class Adafruit_SSD1675B(Adafruit_EPD):
         if not self._busy:
             time.sleep(3)  # wait 3 seconds
 
-    def write_ram(self, index: Union[0, 1]) -> int:
+    def write_ram(self, index: Literal[0, 1]) -> int:
         """Send the one byte command for starting the RAM write process. Returns
         the byte read at the same time over SPI. index is the RAM buffer, can be
         0 or 1 for tri-color displays."""

--- a/adafruit_epd/ssd1680.py
+++ b/adafruit_epd/ssd1680.py
@@ -16,7 +16,8 @@ from adafruit_epd.epd import Adafruit_EPD
 
 try:
     """Needed for type annotations"""
-    from typing import Union
+    import typing  # pylint: disable=unused-import
+    from typing_extensions import Literal
     from busio import SPI
     from digitalio import DigitalInOut
 
@@ -191,7 +192,7 @@ class Adafruit_SSD1680(Adafruit_EPD):
         if not self._busy:
             time.sleep(3)  # wait 3 seconds
 
-    def write_ram(self, index: Union[0, 1]) -> int:
+    def write_ram(self, index: Literal[0, 1]) -> int:
         """Send the one byte command for starting the RAM write process. Returns
         the byte read at the same time over SPI. index is the RAM buffer, can be
         0 or 1 for tri-color displays."""

--- a/adafruit_epd/ssd1681.py
+++ b/adafruit_epd/ssd1681.py
@@ -15,7 +15,8 @@ import adafruit_framebuf
 from adafruit_epd.epd import Adafruit_EPD
 
 try:
-    from typing import Union
+    import typing  # pylint: disable=unused-import
+    from typing_extensions import Literal
     from busio import SPI
     from digitalio import DigitalInOut
 
@@ -173,7 +174,7 @@ class Adafruit_SSD1681(Adafruit_EPD):
         if not self._busy:
             time.sleep(3)  # wait 3 seconds
 
-    def write_ram(self, index: Union[0, 1]) -> int:
+    def write_ram(self, index: Literal[0, 1]) -> int:
         """Send the one byte command for starting the RAM write process. Returns
         the byte read at the same time over SPI. index is the RAM buffer, can be
         0 or 1 for tri-color displays."""

--- a/adafruit_epd/uc8151d.py
+++ b/adafruit_epd/uc8151d.py
@@ -16,7 +16,8 @@ from adafruit_epd.epd import Adafruit_EPD
 
 try:
     """Needed for type annotations"""
-    from typing import Union
+    import typing  # pylint: disable=unused-import
+    from typing_extensions import Literal
     from busio import SPI
     from digitalio import DigitalInOut
 
@@ -152,7 +153,7 @@ class Adafruit_UC8151D(Adafruit_EPD):
         if not self._busy:
             time.sleep(15)  # wait 15 seconds
 
-    def write_ram(self, index: Union[0, 1]) -> int:
+    def write_ram(self, index: Literal[0, 1]) -> int:
         """Send the one byte command for starting the RAM write process. Returns
         the byte read at the same time over SPI. index is the RAM buffer, can be
         0 or 1 for tri-color displays."""


### PR DESCRIPTION
Fixes #76, which was using `Union` where `Literal` is needed in some places.