### PR TITLE
ssd1681: Fix OverflowError for displays larger than 255x255.

### DIFF
--- a/adafruit_epd/ssd1681.py
+++ b/adafruit_epd/ssd1681.py
@@ -143,7 +143,7 @@ class Adafruit_SSD1681(Adafruit_EPD):
         # driver output control
         self.command(
             _SSD1681_DRIVER_CONTROL,
-            bytearray([self._width - 1, (self._width - 1) >> 8, 0x00]),
+            bytearray([(self._width - 1) & 0xFF, (self._width - 1) >> 8, 0x00]),
         )
         # data entry mode
         self.command(_SSD1681_DATA_MODE, bytearray([0x03]))
@@ -152,7 +152,7 @@ class Adafruit_SSD1681(Adafruit_EPD):
         # Set ram Y start/end postion
         self.command(
             _SSD1681_SET_RAMYPOS,
-            bytearray([0, 0, self._height - 1, (self._height - 1) >> 8]),
+            bytearray([0, 0, (self._height - 1) & 0xFF, (self._height - 1) >> 8]),
         )
         # Set border waveform
         self.command(_SSD1681_WRITE_BORDER, bytearray([0x05]))
@@ -190,4 +190,4 @@ class Adafruit_SSD1681(Adafruit_EPD):
         # Set RAM X address counter
         self.command(_SSD1681_SET_RAMXCOUNT, bytearray([x]))
         # Set RAM Y address counter
-        self.command(_SSD1681_SET_RAMYCOUNT, bytearray([y, y >> 8]))
+        self.command(_SSD1681_SET_RAMYCOUNT, bytearray([y & 0xFF, y >> 8]))


### PR DESCRIPTION
When trying to use this driver with a display with dimensions larger than 255x255, the arithmetic operations that attempt to format the width and height into a pair of bytes in the ssd1681 driver's `power_up` function leaves extra overflowing high-order bits in the low-order byte, resulting in an error: `OverflowError: value must fit in 1 byte(s)`, originating from line 146 (for widths larger than 255) or 153 (for heights larger than 255).

This PR fixes this by explicitly masking out just the low byte; it also fixes another instance of this pattern in `set_ram_address` (though I've not gone into detail trying to figure out inputs to actually trigger an error from this instance). 

I've tested this change using an 400x300 [HINK-E042A88](https://www.lcsc.com/product-detail/E-ink-Display_SEEKINK-E042A88_C41416468.html) SSD1683 display, connected via an [Adafruit eInk Feather Friend](https://www.adafruit.com/product/4446) to my [Adafruit Feather RP2040](https://www.adafruit.com/product/4884).

Based on my tests I can confirm that this PR addresses the above issue; display operations appear to run correctly with it.