### PR TITLE
adding ssd1680 legacy for pre-2024 bonnet

### DIFF
--- a/adafruit_epd/ssd1680_legacy.py
+++ b/adafruit_epd/ssd1680_legacy.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2018 Dean Miller for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_epd.ssd1680_legacy` - Adafruit SSD1680 Legacy - ePaper display driver
+====================================================================================
+CircuitPython driver for older Adafruit SSD1680 display breakouts
+ex: pre-2024 2.13" Monochrome E-Ink Bonnet
+* Author(s): Melissa LeBlanc-Williams
+"""
+
+from adafruit_epd.ssd1680 import Adafruit_SSD1680
+
+_SSD1680_DRIVER_CONTROL = 0x01
+_SSD1680_SET_RAMXPOS = 0x44
+_SSD1680_SET_RAMYPOS = 0x45
+_SSD1680_SET_RAMXCOUNT = 0x4E
+_SSD1680_SET_RAMYCOUNT = 0x4F
+_SSD1680_WRITE_VCOM_REG = 0x2C
+_SSD1680_GATE_VOLTAGE = 0x03
+_SSD1680_SOURCE_VOLTAGE = 0x04
+_SSD1680_DATA_MODE = 0x11
+_SSD1680_WRITE_BORDER = 0x3C
+_SSD1680_SW_RESET = 0x12
+
+
+class Adafruit_SSD1680_Legacy(Adafruit_SSD1680):
+    """Driver for older SSD1680 ePaper displays (pre-2024 2.13" Monochrome E-Ink Bonnet)"""
+
+    def power_up(self) -> None:
+        """Power up the display in preparation for writing RAM and updating"""
+        self.hardware_reset()
+        self.busy_wait()
+        self.command(_SSD1680_SW_RESET)
+        self.busy_wait()
+        # driver output control
+        self.command(
+            _SSD1680_DRIVER_CONTROL,
+            bytearray([self._height - 1, (self._height - 1) >> 8, 0x00]),
+        )
+        # data entry mode
+        self.command(_SSD1680_DATA_MODE, bytearray([0x03]))
+
+        # Set voltages
+        self.command(_SSD1680_WRITE_VCOM_REG, bytearray([0x36]))
+        self.command(_SSD1680_GATE_VOLTAGE, bytearray([0x17]))
+        self.command(_SSD1680_SOURCE_VOLTAGE, bytearray([0x41, 0x00, 0x32]))
+
+        # Set ram X start/end postion
+        self.command(_SSD1680_SET_RAMXPOS, bytearray([0x01, 0x10]))
+        # Set ram Y start/end postion
+        self.command(
+            _SSD1680_SET_RAMYPOS,
+            bytearray([0, 0, self._height - 1, (self._height - 1) >> 8]),
+        )
+        # Set border waveform
+        self.command(_SSD1680_WRITE_BORDER, bytearray([0x05]))
+
+        # Set ram X count
+        self.command(_SSD1680_SET_RAMXCOUNT, bytearray([0x01]))
+        # Set ram Y count
+        self.command(_SSD1680_SET_RAMYCOUNT, bytearray([self._height - 1, 0]))
+        self.busy_wait()
+
+    def set_ram_address(self, x: int, y: int) -> None:
+        """Set the RAM address location, not used on this chipset but required by
+        the superclass"""
+        # Set RAM X address counter
+        self.command(_SSD1680_SET_RAMXCOUNT, bytearray([x + 1]))
+        # Set RAM Y address counter
+        self.command(_SSD1680_SET_RAMYCOUNT, bytearray([y, y >> 8]))

--- a/adafruit_epd/ssd1680_legacy.py
+++ b/adafruit_epd/ssd1680_legacy.py
@@ -10,19 +10,21 @@ ex: pre-2024 2.13" Monochrome E-Ink Bonnet
 * Author(s): Melissa LeBlanc-Williams
 """
 
+from micropython import const
+
 from adafruit_epd.ssd1680 import Adafruit_SSD1680
 
-_SSD1680_DRIVER_CONTROL = 0x01
-_SSD1680_SET_RAMXPOS = 0x44
-_SSD1680_SET_RAMYPOS = 0x45
-_SSD1680_SET_RAMXCOUNT = 0x4E
-_SSD1680_SET_RAMYCOUNT = 0x4F
-_SSD1680_WRITE_VCOM_REG = 0x2C
-_SSD1680_GATE_VOLTAGE = 0x03
-_SSD1680_SOURCE_VOLTAGE = 0x04
-_SSD1680_DATA_MODE = 0x11
-_SSD1680_WRITE_BORDER = 0x3C
-_SSD1680_SW_RESET = 0x12
+_SSD1680_DRIVER_CONTROL = const(0x01)
+_SSD1680_SET_RAMXPOS = const(0x44)
+_SSD1680_SET_RAMYPOS = const(0x45)
+_SSD1680_SET_RAMXCOUNT = const(0x4E)
+_SSD1680_SET_RAMYCOUNT = const(0x4F)
+_SSD1680_WRITE_VCOM_REG = const(0x2C)
+_SSD1680_GATE_VOLTAGE = const(0x03)
+_SSD1680_SOURCE_VOLTAGE = const(0x04)
+_SSD1680_DATA_MODE = const(0x11)
+_SSD1680_WRITE_BORDER = const(0x3C)
+_SSD1680_SW_RESET = const(0x12)
 
 
 class Adafruit_SSD1680_Legacy(Adafruit_SSD1680):
@@ -64,8 +66,7 @@ class Adafruit_SSD1680_Legacy(Adafruit_SSD1680):
         self.busy_wait()
 
     def set_ram_address(self, x: int, y: int) -> None:
-        """Set the RAM address location, not used on this chipset but required by
-        the superclass"""
+        """Set the RAM address location"""
         # Set RAM X address counter
         self.command(_SSD1680_SET_RAMXCOUNT, bytearray([x + 1]))
         # Set RAM Y address counter

--- a/examples/epd_bitmap.py
+++ b/examples/epd_bitmap.py
@@ -13,6 +13,7 @@ from adafruit_epd.il91874 import Adafruit_IL91874
 from adafruit_epd.ssd1608 import Adafruit_SSD1608
 from adafruit_epd.ssd1675 import Adafruit_SSD1675
 from adafruit_epd.ssd1680 import Adafruit_SSD1680
+from adafruit_epd.ssd1680_legacy import Adafruit_SSD1680_Legacy
 from adafruit_epd.ssd1680b import Adafruit_SSD1680B
 from adafruit_epd.ssd1681 import Adafruit_SSD1681
 from adafruit_epd.ssd1683 import Adafruit_SSD1683
@@ -33,6 +34,7 @@ print("Creating display")
 # display = Adafruit_SSD1675(122, 250,        # 2.13" HD mono display
 # display = Adafruit_SSD1680(122, 250,        # 2.13" HD Tri-color display
 # display = Adafruit_SSD1680B(122, 250        # Newer 2.13" HD (Tri-color or mono) with GDEY0213B74
+# display = Adafruit_SSD1680_Legacy(122, 250, # pre-2024 SSD1680 Bonnet
 # display = Adafruit_SSD1681(200, 200,        # 1.54" HD Tri-color display
 # display = Adafruit_IL91874(176, 264,        # 2.7" Tri-color display
 # display = Adafruit_EK79686(176, 264,        # 2.7" Tri-color display

--- a/examples/epd_blinka.py
+++ b/examples/epd_blinka.py
@@ -16,6 +16,7 @@ from adafruit_epd.ssd1608 import Adafruit_SSD1608
 from adafruit_epd.ssd1675 import Adafruit_SSD1675
 from adafruit_epd.ssd1675b import Adafruit_SSD1675B
 from adafruit_epd.ssd1680 import Adafruit_SSD1680
+from adafruit_epd.ssd1680_legacy import Adafruit_SSD1680_Legacy
 from adafruit_epd.ssd1680b import Adafruit_SSD1680B
 from adafruit_epd.ssd1681 import Adafruit_SSD1681
 from adafruit_epd.ssd1683 import Adafruit_SSD1683
@@ -37,6 +38,7 @@ print("Creating display")
 # display = Adafruit_SSD1608(200, 200,        # 1.54" HD mono display
 # display = Adafruit_SSD1680(122, 250,        # 2.13" HD Tri-color display
 # display = Adafruit_SSD1680B(122, 250        # Newer 2.13" HD (Tri-color or mono) with GDEY0213B74
+# display = Adafruit_SSD1680_Legacy(122, 250, # pre-2024 SSD1680 Bonnet
 # display = Adafruit_SSD1681(200, 200,        # 1.54" HD Tri-color display
 # display = Adafruit_SSD1675(122, 250,        # 2.13" HD mono display
 # display = Adafruit_SSD1683(400, 300,        # 4.2" 300x400 Tri-Color display

--- a/examples/epd_bonnet.py
+++ b/examples/epd_bonnet.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
-
 import time
 
 import board
@@ -11,6 +10,7 @@ from PIL import Image, ImageDraw, ImageFont
 from adafruit_epd.epd import Adafruit_EPD
 from adafruit_epd.ssd1675b import Adafruit_SSD1675B
 from adafruit_epd.ssd1680 import Adafruit_SSD1680
+from adafruit_epd.ssd1680_legacy import Adafruit_SSD1680_Legacy
 from adafruit_epd.ssd1680b import Adafruit_SSD1680B
 
 # create two buttons
@@ -28,7 +28,8 @@ busy = DigitalInOut(board.D17)
 
 # give them all to our driver
 # display = Adafruit_SSD1675B(   # Oldest 2.13" Bonnet
-# display = Adafruit_SSD1680(    # Old 2.13" Bonnet
+# display = Adafruit_SSD1680_Legacy( # pre-2024 SSD1680 Bonnet
+# display = Adafruit_SSD1680(    # 2.13" Bonnet
 display = Adafruit_SSD1680B(  # Newer 2.13" HD (Tri-color or mono) with GDEY0213B74
     122,
     250,

--- a/examples/epd_pillow_demo.py
+++ b/examples/epd_pillow_demo.py
@@ -19,6 +19,7 @@ from adafruit_epd.jd79661 import Adafruit_JD79661
 from adafruit_epd.ssd1608 import Adafruit_SSD1608
 from adafruit_epd.ssd1675 import Adafruit_SSD1675
 from adafruit_epd.ssd1680 import Adafruit_SSD1680
+from adafruit_epd.ssd1680_legacy import Adafruit_SSD1680_Legacy
 from adafruit_epd.ssd1680b import Adafruit_SSD1680B
 from adafruit_epd.ssd1681 import Adafruit_SSD1681
 from adafruit_epd.ssd1683 import Adafruit_SSD1683
@@ -50,7 +51,8 @@ busy = digitalio.DigitalInOut(board.D17)
 # display = Adafruit_SSD1608(200, 200,        # 1.54" HD mono display
 # display = Adafruit_SSD1675(122, 250,        # 2.13" HD mono display
 # display = Adafruit_SSD1680(122, 250,        # 2.13" HD Tri-color or mono display
-# display = Adafruit_SSD1680B(122, 250        # Newer 2.13" HD (Tri-color or mono) with GDEY0213B74
+# display = Adafruit_SSD1680B(122, 250,       # Newer 2.13" HD (Tri-color or mono) with GDEY0213B74
+# display = Adafruit_SSD1680_Legacy(122, 250, # pre-2024 SSD1680 Bonnet
 # display = Adafruit_SSD1681(200, 200,        # 1.54" HD Tri-color display
 # display = Adafruit_IL91874(176, 264,        # 2.7" Tri-color display
 # display = Adafruit_EK79686(176, 264,        # 2.7" Tri-color display

--- a/examples/epd_pillow_image.py
+++ b/examples/epd_pillow_image.py
@@ -21,6 +21,7 @@ from adafruit_epd.jd79661 import Adafruit_JD79661
 from adafruit_epd.ssd1608 import Adafruit_SSD1608
 from adafruit_epd.ssd1675 import Adafruit_SSD1675
 from adafruit_epd.ssd1680 import Adafruit_SSD1680
+from adafruit_epd.ssd1680_legacy import Adafruit_SSD1680_Legacy
 from adafruit_epd.ssd1680b import Adafruit_SSD1680B
 from adafruit_epd.ssd1681 import Adafruit_SSD1681
 from adafruit_epd.ssd1683 import Adafruit_SSD1683
@@ -40,7 +41,8 @@ busy = digitalio.DigitalInOut(board.D17)
 # display = Adafruit_SSD1608(200, 200,        # 1.54" HD mono display
 # display = Adafruit_SSD1675(122, 250,        # 2.13" HD mono display
 # display = Adafruit_SSD1680(122, 250,        # 2.13" HD Tri-color or mono display
-# display = Adafruit_SSD1680B(122, 250        # Newer 2.13" HD (Tri-color or mono) with GDEY0213B74
+# display = Adafruit_SSD1680B(122, 250,       # Newer 2.13" HD (Tri-color or mono) with GDEY0213B74
+# display = Adafruit_SSD1680_Legacy(122, 250, # pre-2024 SSD1680 Bonnet
 # display = Adafruit_SSD1681(200, 200,        # 1.54" HD Tri-color display
 # display = Adafruit_IL91874(176, 264,        # 2.7" Tri-color display
 # display = Adafruit_EK79686(176, 264,        # 2.7" Tri-color display


### PR DESCRIPTION
adding an ssd1680 legacy driver for compatibility with pre-2024 2.13" bonnet. the current ssd1680 driver was [fixed](https://github.com/adafruit/Adafruit_CircuitPython_EPD/commit/04032f3b2bac64b83e0ddd66aec981249963e736) for greater compatibility with other ssd1680 displays. this was brought up in https://github.com/adafruit/Adafruit_CircuitPython_EPD/issues/101