### PR TITLE
Add SSD1675A gray 4-level support to 2.13" #4195 (pre-April 2020)

### DIFF
--- a/adafruit_epd/ssd1675a_grayscale4.py
+++ b/adafruit_epd/ssd1675a_grayscale4.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: 2025 Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+`adafruit_epd.ssd1675a_grayscale4` - 4-level grayscale driver for SSD1675A (IL3897)
+=====================================================================================
+CircuitPython driver for Adafruit SSD1675A ePaper display breakouts in 4-gray mode.
+
+Confirmed hardware: HINK E0213A22-A0 SLH 1852, Adafruit #4195 (pre-April 2020 revision).
+
+Identify your hardware: read the FPC ribbon label on the panel edge.
+  "HINK E0213A22-A0" → SSD1675A (this driver)
+  Any Good Display label (GDEY0213B74, etc.) → SSD1680 (use Adafruit_SSD1680)
+
+Critical differences from 2-color SSD1675 init:
+  1. Voltage commands (EOPQ/VGH/VSH/VCOM) must come AFTER the LUT write.
+  2. 0x3A (dummy line period) and 0x3B (gate line width) must be omitted.
+  3. VCOM=0x28 (not 0x70 — the 2-color value overdrives grayscale).
+  4. Double-pass refresh: write buffers and activate twice for clean output.
+
+* Author(s): Adafruit Industries
+"""
+
+import time
+
+from micropython import const
+
+from adafruit_epd.epd import Adafruit_EPD
+from adafruit_epd.ssd1675 import Adafruit_SSD1675
+
+try:
+    from busio import SPI
+    from digitalio import DigitalInOut
+except ImportError:
+    pass
+
+__version__ = "0.0.0+auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_EPD.git"
+
+_SSD1675A_SW_RESET = const(0x12)
+_SSD1675A_SET_ANALOGBLOCK = const(0x74)
+_SSD1675A_SET_DIGITALBLOCK = const(0x7E)
+_SSD1675A_DRIVER_CONTROL = const(0x01)
+_SSD1675A_DATA_MODE = const(0x11)
+_SSD1675A_WRITE_BORDER = const(0x3C)
+_SSD1675A_DISP_CTRL1 = const(0x21)
+_SSD1675A_DISP_CTRL2 = const(0x22)
+_SSD1675A_MASTER_ACTIVATE = const(0x20)
+_SSD1675A_SET_RAMXPOS = const(0x44)
+_SSD1675A_SET_RAMYPOS = const(0x45)
+_SSD1675A_SET_RAMXCOUNT = const(0x4E)
+_SSD1675A_SET_RAMYCOUNT = const(0x4F)
+_SSD1675A_WRITE_LUT = const(0x32)
+_SSD1675A_WRITE_RAM1 = const(0x24)
+_SSD1675A_WRITE_RAM2 = const(0x26)
+_SSD1675A_END_OPTION = const(0x3F)
+_SSD1675A_GATE_VOLTAGE = const(0x03)
+_SSD1675A_SOURCE_VOLTAGE = const(0x04)
+_SSD1675A_WRITE_VCOM = const(0x2C)
+
+# pux4j GRAY4_LUT (153 bytes): VS rows + timing groups + FR/XON.
+# Source: darranl/pux4j (Java/Pi4J, SSD1675A 2.9" panel), adapted for 250×122.
+# 0x60 DC balance — works reliably from any prior display state.
+# (The GxEPD2 0x48 LUT fails from a clean all-white prior state on SSD1675A.)
+_GRAY4_LUT = bytes([
+    # VS rows (5 × 12 bytes)
+    0x00, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  # L0 white
+    0x20, 0x60, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  # L1 light gray
+    0x28, 0x60, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  # L2 dark gray
+    0x2A, 0x60, 0x15, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  # L3 black
+    0x00, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  # L4 VCOM
+    # Timing groups (12 × 7 bytes)
+    0x00, 0x02, 0x00, 0x05, 0x14, 0x00, 0x00,  # G0
+    0x1E, 0x1E, 0x00, 0x00, 0x00, 0x00, 0x01,  # G1 (RP=1)
+    0x00, 0x02, 0x00, 0x05, 0x14, 0x00, 0x00,  # G2
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  # G3–G11: zeros
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    # FR / XON (9 bytes)
+    0x24, 0x22, 0x22, 0x22, 0x23, 0x32, 0x00, 0x00, 0x00,
+])
+
+
+class Adafruit_SSD1675A_Grayscale4(Adafruit_SSD1675):
+    """4-level grayscale driver for SSD1675A (IL3897) ePaper displays.
+
+    Tested on Adafruit #4195 2.13" eInk FeatherWing (pre-April 2020,
+    panel FPC label: HINK E0213A22-A0).
+
+    Pass width=122, height=250 to match the 250×122 panel RAM layout.
+
+    Four color constants are available::
+
+        WHITE      = 1   # L0 — BW=1, COLOR=0
+        LIGHT_GRAY = 2   # L1 — BW=1, COLOR=1
+        DARK_GRAY  = 3   # L2 — BW=0, COLOR=1
+        BLACK      = 0   # L3 — BW=0, COLOR=0
+
+    Usage::
+
+        import busio, board, digitalio
+        from adafruit_epd.ssd1675a_grayscale4 import Adafruit_SSD1675A_Grayscale4
+
+        spi = busio.SPI(board.SCK, MOSI=board.MOSI)
+        display = Adafruit_SSD1675A_Grayscale4(
+            122, 250, spi,
+            cs_pin=digitalio.DigitalInOut(board.D9),
+            dc_pin=digitalio.DigitalInOut(board.D10),
+            sramcs_pin=None,
+            rst_pin=digitalio.DigitalInOut(board.D11),
+            busy_pin=digitalio.DigitalInOut(board.D12),
+        )
+        display.fill(Adafruit_SSD1675A_Grayscale4.WHITE)
+        display.fill_rect(0, 0, 60, 250, Adafruit_SSD1675A_Grayscale4.BLACK)
+        display.display()
+    """
+
+    LIGHT_GRAY = const(2)
+    DARK_GRAY = const(3)
+
+    def __init__(self, width, height, spi, *, cs_pin, dc_pin, sramcs_pin,
+                 rst_pin, busy_pin):
+        super().__init__(width, height, spi, cs_pin=cs_pin, dc_pin=dc_pin,
+                         sramcs_pin=sramcs_pin, rst_pin=rst_pin, busy_pin=busy_pin)
+        # Parent sets both framebuffers to _framebuf1 (monochrome). Redirect
+        # the color framebuffer to _framebuf2 so drawing ops use both RAM banks.
+        self.set_color_buffer(1, False)
+
+    # ------------------------------------------------------------------
+    # 4-gray drawing API
+    # ------------------------------------------------------------------
+
+    def _color_dup(self, func, args, color):
+        """Set a pixel or region in both BW and COLOR RAM for 4-gray output.
+
+        BW RAM:    1 = white/light-gray tendency  (L0 / L1)
+        COLOR RAM: 1 = gray pixel (L1 / L2)
+
+        Resulting LUT state per pixel:
+          WHITE(1)      BW=1 COLOR=0 → L0
+          LIGHT_GRAY(2) BW=1 COLOR=1 → L1
+          DARK_GRAY(3)  BW=0 COLOR=1 → L2
+          BLACK(0)      BW=0 COLOR=0 → L3
+        """
+        bw_fn = getattr(self._blackframebuf, func)
+        color_fn = getattr(self._colorframebuf, func)
+        bw_bit = color in (Adafruit_EPD.WHITE, 2)    # LIGHT_GRAY=2
+        color_bit = color in (2, 3)                  # LIGHT_GRAY=2, DARK_GRAY=3
+        bw_fn(*args, color=bw_bit)
+        color_fn(*args, color=color_bit)
+
+    def pixel(self, x, y, color):
+        """Set one pixel to one of the four gray levels."""
+        self._color_dup("pixel", (x, y), color)
+
+    def fill_rect(self, x, y, width, height, color):
+        """Fill a rectangle with one of the four gray levels."""
+        self._color_dup("fill_rect", (x, y, width, height), color)
+
+    def fill(self, color):
+        """Fill the entire display with one of the four gray levels."""
+        bw_byte = 0xFF if color in (Adafruit_EPD.WHITE, 2) else 0x00
+        color_byte = 0xFF if color in (2, 3) else 0x00
+        if self.sram:
+            self.sram.erase(0x00, self._buffer1_size, bw_byte)
+            self.sram.erase(self._buffer1_size, self._buffer2_size, color_byte)
+        else:
+            self._blackframebuf.fill(bw_byte)
+            self._colorframebuf.fill(color_byte)
+
+    # ------------------------------------------------------------------
+    # Hardware control
+    # ------------------------------------------------------------------
+
+    def _send(self, cmd, data=None) -> None:
+        """Send one command+data with the SPI bus already locked by the caller."""
+        self._cs.value = False
+        self._dc.value = False
+        self.spi_device.write(bytearray([cmd]))
+        if data is not None:
+            self._dc.value = True
+            self.spi_device.write(
+                bytearray(data) if isinstance(data, bytes) else data
+            )
+        self._cs.value = True
+
+    def _set_ram_window(self) -> None:
+        """Set RAM X/Y window and reset counters to (0,0). SPI must be locked."""
+        self._send(_SSD1675A_SET_RAMXPOS, bytearray([0x00, 0x0F]))
+        self._send(_SSD1675A_SET_RAMYPOS, bytearray([0x00, 0x00, 0xF9, 0x00]))
+        self._send(_SSD1675A_SET_RAMXCOUNT, bytearray([0x00]))
+        self._send(_SSD1675A_SET_RAMYCOUNT, bytearray([0x00, 0x00]))
+
+    def display(self) -> None:
+        """Double-pass refresh for clean 4-gray output.
+
+        The SPI bus is held locked for the entire sequence. Releasing and
+        re-acquiring the lock between commands corrupts the SSD1675A controller
+        state, preventing the custom LUT refresh from triggering.
+
+        Pass 1 establishes the prior pixel state; pass 2 drives cleanly to
+        the target gray level.
+        """
+        while not self.spi_device.try_lock():
+            time.sleep(0.01)
+        try:
+            for _ in range(2):
+                # Hardware reset is GPIO — safe while SPI is locked
+                self.hardware_reset()
+                time.sleep(0.02)
+
+                self._send(_SSD1675A_SW_RESET)
+                time.sleep(0.02)
+
+                self._send(_SSD1675A_SET_ANALOGBLOCK, bytearray([0x54]))
+                self._send(_SSD1675A_SET_DIGITALBLOCK, bytearray([0x3B]))
+                self._send(_SSD1675A_DRIVER_CONTROL, bytearray([0xF9, 0x00, 0x00]))
+                self._send(_SSD1675A_DATA_MODE, bytearray([0x03]))
+                self._send(_SSD1675A_WRITE_BORDER, bytearray([0x03]))
+                self._send(_SSD1675A_DISP_CTRL1, bytearray([0x00, 0x80]))
+                self._set_ram_window()
+
+                # LUT first, then voltage — ordering critical for SSD1675A 4-gray
+                self._send(_SSD1675A_WRITE_LUT, _GRAY4_LUT)
+                self._send(_SSD1675A_END_OPTION, bytearray([0x22]))
+                self._send(_SSD1675A_GATE_VOLTAGE, bytearray([0x17]))
+                self._send(_SSD1675A_SOURCE_VOLTAGE, bytearray([0x41, 0xAE, 0x32]))
+                self._send(_SSD1675A_WRITE_VCOM, bytearray([0x28]))
+                self._send(_SSD1675A_DISP_CTRL2, bytearray([0xC7]))
+
+                # BW RAM — reset window before each write
+                self._set_ram_window()
+                self._cs.value = False
+                self._dc.value = False
+                self.spi_device.write(bytearray([_SSD1675A_WRITE_RAM1]))
+                self._dc.value = True
+                self.spi_device.write(self._buffer1)
+                self._cs.value = True
+                time.sleep(0.002)
+
+                # COLOR RAM
+                self._set_ram_window()
+                self._cs.value = False
+                self._dc.value = False
+                self.spi_device.write(bytearray([_SSD1675A_WRITE_RAM2]))
+                self._dc.value = True
+                self.spi_device.write(self._buffer2)
+                self._cs.value = True
+
+                self._send(_SSD1675A_MASTER_ACTIVATE)
+                time.sleep(3.0)
+        finally:
+            self.spi_device.unlock()

--- a/examples/epd_simpletest.py
+++ b/examples/epd_simpletest.py
@@ -13,6 +13,7 @@ from adafruit_epd.il91874 import Adafruit_IL91874
 from adafruit_epd.jd79661 import Adafruit_JD79661
 from adafruit_epd.ssd1608 import Adafruit_SSD1608
 from adafruit_epd.ssd1675 import Adafruit_SSD1675
+from adafruit_epd.ssd1675a_grayscale4 import Adafruit_SSD1675A_Grayscale4
 from adafruit_epd.ssd1680 import Adafruit_SSD1680
 from adafruit_epd.ssd1680b import Adafruit_SSD1680B
 from adafruit_epd.ssd1681 import Adafruit_SSD1681
@@ -33,6 +34,7 @@ print("Creating display")
 # display = Adafruit_JD79661(122, 150,        # 2.13" Quad-color display
 # display = Adafruit_SSD1608(200, 200,        # 1.54" HD mono display
 # display = Adafruit_SSD1675(122, 250,        # 2.13" HD mono display
+# display = Adafruit_SSD1675A_Grayscale4(122, 250,  # 2.13" 4-gray display (HINK E0213A22-A0, pre-April 2020)
 # display = Adafruit_SSD1680(122, 250,        # 2.13" HD Tri-color display
 # display = Adafruit_SSD1680B(122, 250        # 2.13" HD (Tri-color or mono) with GDEY0213B74
 # display = Adafruit_SSD1681(200, 200,        # 1.54" HD Tri-color display

--- a/examples/epd_ssd1675a_grayscale4_simpletest.py
+++ b/examples/epd_ssd1675a_grayscale4_simpletest.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2025 Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+"""
+4-level grayscale example for the Adafruit 2.13" eInk FeatherWing
+pre-April 2020 revision (controller: SSD1675A / IL3897).
+
+Identify your hardware: read the FPC ribbon label on the panel edge.
+  "HINK E0213A22-A0" → SSD1675A — use this example
+  Any Good Display label (GDEY0213B74, etc.) → SSD1680 — use Adafruit_SSD1680
+
+Wiring (FeatherWing plugs directly onto any Feather):
+  SCK  → SCK    MOSI → MOSI
+  CS   → D9     DC   → D10
+  RST  → D11    BUSY → D12
+"""
+
+import board
+import busio
+import digitalio
+
+from adafruit_epd.epd import Adafruit_EPD
+from adafruit_epd.ssd1675a_grayscale4 import Adafruit_SSD1675A_Grayscale4
+
+spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
+ecs = digitalio.DigitalInOut(board.D9)
+dc = digitalio.DigitalInOut(board.D10)
+srcs = None  # no SRAM on FeatherWing (use digitalio.DigitalInOut(board.D6) if present)
+rst = digitalio.DigitalInOut(board.D11)
+busy = digitalio.DigitalInOut(board.D12)
+
+print("Creating display")
+display = Adafruit_SSD1675A_Grayscale4(
+    122, 250,  # 2.13" 4-gray display (HINK E0213A22-A0, pre-April 2020)
+    spi,
+    cs_pin=ecs,
+    dc_pin=dc,
+    sramcs_pin=srcs,
+    rst_pin=rst,
+    busy_pin=busy,
+)
+
+# Four gray levels — use these instead of the 2-color Adafruit_EPD constants
+WHITE = Adafruit_SSD1675A_Grayscale4.WHITE        # L0 — lightest
+LIGHT_GRAY = Adafruit_SSD1675A_Grayscale4.LIGHT_GRAY  # L1
+DARK_GRAY = Adafruit_SSD1675A_Grayscale4.DARK_GRAY    # L2
+BLACK = Adafruit_SSD1675A_Grayscale4.BLACK        # L3 — darkest
+
+print("Clear buffer")
+display.fill(WHITE)
+
+print("Draw rectangles")
+display.fill_rect(5, 5, 50, 50, LIGHT_GRAY)
+display.fill_rect(60, 5, 50, 50, DARK_GRAY)
+display.fill_rect(5, 60, 50, 50, BLACK)
+display.rect(60, 60, 50, 50, DARK_GRAY)
+
+print("Draw lines")
+display.line(0, 0, display.width - 1, display.height - 1, BLACK)
+display.line(0, display.height - 1, display.width - 1, 0, DARK_GRAY)
+
+print("Draw text")
+display.text("4-gray!", 25, 120, BLACK)
+
+print("Refreshing display (~6 s)...")
+display.display()
+print("Done")

--- a/examples/epd_ssd1675a_grayscale4_simpletest.py
+++ b/examples/epd_ssd1675a_grayscale4_simpletest.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-4-level grayscale example for the Adafruit 2.13" eInk FeatherWing
+4-level grayscale testcard for the Adafruit 2.13" eInk FeatherWing
 pre-April 2020 revision (controller: SSD1675A / IL3897).
 
 Identify your hardware: read the FPC ribbon label on the panel edge.
@@ -18,9 +18,11 @@ Wiring (FeatherWing plugs directly onto any Feather):
 import board
 import busio
 import digitalio
+import displayio
 
-from adafruit_epd.epd import Adafruit_EPD
 from adafruit_epd.ssd1675a_grayscale4 import Adafruit_SSD1675A_Grayscale4
+
+displayio.release_displays()
 
 spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 ecs = digitalio.DigitalInOut(board.D9)
@@ -39,28 +41,56 @@ display = Adafruit_SSD1675A_Grayscale4(
     rst_pin=rst,
     busy_pin=busy,
 )
+display.rotation = 1  # landscape: width=250, height=122
 
-# Four gray levels — use these instead of the 2-color Adafruit_EPD constants
-WHITE = Adafruit_SSD1675A_Grayscale4.WHITE        # L0 — lightest
-LIGHT_GRAY = Adafruit_SSD1675A_Grayscale4.LIGHT_GRAY  # L1
-DARK_GRAY = Adafruit_SSD1675A_Grayscale4.DARK_GRAY    # L2
-BLACK = Adafruit_SSD1675A_Grayscale4.BLACK        # L3 — darkest
+WHITE      = Adafruit_SSD1675A_Grayscale4.WHITE
+LIGHT_GRAY = Adafruit_SSD1675A_Grayscale4.LIGHT_GRAY
+DARK_GRAY  = Adafruit_SSD1675A_Grayscale4.DARK_GRAY
+BLACK      = Adafruit_SSD1675A_Grayscale4.BLACK
 
-print("Clear buffer")
+W = display.width   # 250
+H = display.height  # 122
+
+# Column x-starts and row y-starts
+C0, C1, C2, C3 = 0, 62, 125, 188
+R_HDR, R_BARS, R_DITH, R_CHK = 0, 14, 56, 98
+
+print("Drawing testcard")
 display.fill(WHITE)
 
-print("Draw rectangles")
-display.fill_rect(5, 5, 50, 50, LIGHT_GRAY)
-display.fill_rect(60, 5, 50, 50, DARK_GRAY)
-display.fill_rect(5, 60, 50, 50, BLACK)
-display.rect(60, 60, 50, 50, DARK_GRAY)
+# Header: black bar with white text
+display.fill_rect(0, R_HDR, W, 14, BLACK)
+display.text("SSD1675A  pux4j LUT  VCOM=0x28", 4, 4, WHITE)
 
-print("Draw lines")
-display.line(0, 0, display.width - 1, display.height - 1, BLACK)
-display.line(0, display.height - 1, display.width - 1, 0, DARK_GRAY)
+# Solid gray bars
+display.fill_rect(C0, R_BARS, 62, 42, WHITE)
+display.fill_rect(C1, R_BARS, 63, 42, LIGHT_GRAY)
+display.fill_rect(C2, R_BARS, 63, 42, DARK_GRAY)
+display.fill_rect(C3, R_BARS, 62, 42, BLACK)
 
-print("Draw text")
-display.text("4-gray!", 25, 120, BLACK)
+# Horizontal-line dither rows (42 rows, alternating each column pair)
+for row in range(R_DITH, R_DITH + 42):
+    e = row % 2 == 0
+    display.fill_rect(C0, row, 62, 1, WHITE      if e else BLACK)
+    display.fill_rect(C1, row, 63, 1, WHITE      if e else LIGHT_GRAY)
+    display.fill_rect(C2, row, 63, 1, LIGHT_GRAY if e else DARK_GRAY)
+    display.fill_rect(C3, row, 62, 1, DARK_GRAY  if e else BLACK)
+
+# 2-pixel checkerboard (bottom two bands)
+for by in range(R_CHK, H, 2):
+    for bx in range(0, W, 2):
+        c = WHITE if ((bx // 2) + (by // 2)) % 2 == 0 else BLACK
+        display.fill_rect(bx, by, 2, 2, c)
+
+# Grid lines
+for y in range(R_BARS, H):
+    display.pixel(C1, y, BLACK)
+    display.pixel(C2, y, BLACK)
+    display.pixel(C3, y, BLACK)
+for x in range(W):
+    display.pixel(x, R_BARS, BLACK)
+    display.pixel(x, R_DITH, BLACK)
+    display.pixel(x, R_CHK, BLACK)
 
 print("Refreshing display (~6 s)...")
 display.display()


### PR DESCRIPTION
4-level grayscale driver for the SSD1675A 

[Adafruit #4195 2.13\" eInk FeatherWing](https://www.adafruit.com/product/4195)
- older model (pre-April 2020)
- panel FPC label: `HINK E0213A22-A0`

Uses the [pux4j GRAY4_LUT](https://github.com/darranl/pux4j) (0x60 DC balance) — the only publicly available SSD1675A 4-gray LUT prior to this port, originally written for a 2.9\" panel in Java/Pi4J.

Tested on Feather RP2350

No modification to existing library code. This is a separate constructor, library, example. 