### PR TITLE
FeatherWing 2.9" SSD1680 4-gray #4777 (adafruit_epd)

### DIFF
--- a/examples/feather_epd_grayscale_2in9_4777.py
+++ b/examples/feather_epd_grayscale_2in9_4777.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 Mikey Sklar, written for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+"""4-gray grayscale for the Adafruit 2.9" SSD1680 eInk FeatherWing (#4777), via adafruit_epd.
+
+The framebuf path (companion to the displayio adafruit_ssd1680 driver). Reach for adafruit_epd
+when you want external-SRAM offload or direct framebuffer access. 296x128 GDEM029T94 /
+FPC-7519rev.b. Uses the upstream Adafruit_SSD1680_Grayscale4 class (colstart=0 hardcoded, 296
+gate handled) — no library change; just vcom=0x24 for this panel.
+
+FeatherWing wiring notes (differ from the #4197 EYESPI breakout):
+  CS=D9  DC=D10  SCK/MOSI on the shared bus.
+  BUSY is not connected on the Wing -> busy_pin=None (timed refresh).
+  RST is on the Feather RESET line, not a GPIO -> the panel can only be woken by a Feather
+  hardware reset, so we never deep-sleep it (power_down -> no-op). Run after a power-on/reset.
+"""
+
+import time
+
+import board
+import digitalio
+
+from adafruit_epd.epd import Adafruit_EPD
+from adafruit_epd.ssd1680 import Adafruit_SSD1680_Grayscale4
+
+
+class WingGrayscale4(Adafruit_SSD1680_Grayscale4):
+    # FeatherWing: RST is on the Feather RESET line, so the panel can't be GPIO-reset to wake
+    # from deep sleep -> never deep-sleep it.
+    def power_down(self):
+        pass
+
+
+spi = board.SPI()
+cs = digitalio.DigitalInOut(board.D9)
+dc = digitalio.DigitalInOut(board.D10)
+rst = digitalio.DigitalInOut(board.D11)  # harmless on the Wing (RST not routed here)
+
+display = WingGrayscale4(
+    128,
+    296,
+    spi,
+    cs_pin=cs,
+    dc_pin=dc,
+    sramcs_pin=None,
+    rst_pin=rst,
+    busy_pin=None,  # BUSY not connected on the Wing
+    vcom=0x24,  # FPC-7519rev.b (the class default 0x1C is for GDEY0213B74)
+)
+display.rotation = 3  # landscape; matches the displayio driver's 270
+W = display.width
+print("Init OK — drawing 4-gray info card...")
+
+display.fill(Adafruit_EPD.WHITE)
+display.text("Adafruit ThinkInk", 6, 6, Adafruit_EPD.BLACK, size=2)
+display.text('2.9" 296x128', 6, 28, Adafruit_EPD.BLACK, size=2)
+display.text("4-Gray E-Ink", 6, 50, Adafruit_EPD.DARK, size=2)
+display.text("SSD1680  #4777", 6, 74, Adafruit_EPD.BLACK, size=1)
+
+# 4-level gray ramp across the bottom: black | dark | light | white
+RAMP_TOP, RAMP_H = 100, 24
+SEG = W // 4
+ramp = (Adafruit_EPD.BLACK, Adafruit_EPD.DARK, Adafruit_EPD.LIGHT, Adafruit_EPD.WHITE)
+for i, color in enumerate(ramp):
+    x = i * SEG
+    display.fill_rect(x, RAMP_TOP, SEG if i < 3 else W - x, RAMP_H, color)
+display.rect(0, RAMP_TOP, W, RAMP_H, Adafruit_EPD.BLACK)
+for i in range(1, 4):
+    display.vline(i * SEG, RAMP_TOP, RAMP_H, Adafruit_EPD.BLACK)
+
+print("Refreshing...")
+t0 = time.monotonic()
+display.display()
+print(f"Done in {time.monotonic() - t0:.1f}s")


### PR DESCRIPTION
4-gray for the 2.9" SSD1680 FeatherWing #[4777](https://www.adafruit.com/product/4777)

- Tested on Feather RP2040 + #4777
- Adafruit_SSD1680_Grayscale4 (colstart=0) 
- Example code only, No driver change
- FPC-7519rev.b; class default 0x1C is GDEY0213B74

<img width="946" height="530" alt="4777-epd-grayscale-card" src="https://github.com/user-attachments/assets/158d4552-3975-4b17-bed6-5118d80281dc" />
